### PR TITLE
Allow to add new notes

### DIFF
--- a/frontend/fakenoteprovider.js
+++ b/frontend/fakenoteprovider.js
@@ -5,9 +5,9 @@ class Note {
     content;
     tags;
 
-    constructor(name) {
+    constructor(name, content) {
         this.name = name;
-        this.content = "";
+        this.content = content || "";
         this.tags = [];
     }
 }
@@ -19,7 +19,7 @@ class FakeNoteProvider extends NoteProvider {
     constructor() {
         super();
         this.#notes = new Map([
-            ["Sample", new Note("Sample")]
+            ["Sample", new Note("Sample", "# Sample Note\n")]
         ]);
     }
 
@@ -35,7 +35,7 @@ class FakeNoteProvider extends NoteProvider {
 
     async read(name) {
         const note = this.#get_note(name);
-        return note.name;
+        return note.content;
     }
 
     async create() {

--- a/frontend/fakenoteprovider.js
+++ b/frontend/fakenoteprovider.js
@@ -1,0 +1,86 @@
+import { NoteProvider } from "./noteprovider";
+
+class Note {
+    name;
+    content;
+    tags;
+
+    constructor(name) {
+        this.name = name;
+        this.content = "";
+        this.tags = [];
+    }
+}
+
+class FakeNoteProvider extends NoteProvider {
+
+    #notes;
+
+    constructor() {
+        super();
+        this.#notes = new Map([
+            ["Sample", new Note("Sample")]
+        ]);
+    }
+
+    #get_note(name) {
+        const note = this.#notes.get(name);
+        if (!note) { throw new Error(`unknown note \"${name}\"`); }
+        return note;
+    }
+
+    async list() {
+        return [...this.#notes.keys()];
+    }
+
+    async read(name) {
+        const note = this.#get_note(name);
+        return note.name;
+    }
+
+    async create() {
+        let name = "Untitled";
+        let count = 0;
+        while (this.#notes.has(name)) {
+            count++;
+            name = `Untitled ${count}`;
+        }
+
+        this.#notes.set(name, new Note(name));
+        return name;
+    }
+
+    async rename(old_name, new_name) {
+        const note = this.#get_note(old_name);
+        if (this.#notes.has(new_name)) {
+            throw new Error(`failed to rename to an existing note \"${new_name}\"`);
+        }
+
+        this.#notes.delete(old_name);
+        note.name = new_name;
+        this.#notes.set(note.name, note);
+    }
+
+    async write(name, content) {
+        const note = this.#get_note(name);
+        note.content = content;
+    }
+
+    async remove(name) {
+        if (this.#notes.has(name)) {
+            this.#notes.delete(name);
+        }
+    }
+
+    async read_tags(name) {
+        const note = this.#get_note(name);
+        return note.tags;
+    }
+
+    async write_tags(name, tags) {
+        const note = this.#get_note(name);
+        note.tags = tags;
+    }
+}
+
+export { FakeNoteProvider }

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -8,11 +8,19 @@ import { marked } from "marked"
 import { slider_attach } from "./slider.js"
 import { init_titlebar } from "./titlebar.js"
 import { init_settings } from "./settings.js"
+import { FakeNoteProvider } from "./fakenoteprovider.js"
+import { NoteList } from "./notelist.js"
 
 init_titlebar();
 init_settings();
 slider_attach(document.querySelector("#slider"));
 
+const noteProvider = new FakeNoteProvider();
+const notelist_element = document.querySelector("#notelist");
+const notelist = new NoteList(noteProvider, notelist_element);
+document.querySelector("#add-note").addEventListener("click", async () => {
+  notelist.add_new();
+})
 
 const language = new Compartment();
 const editor_element = document.querySelector("#editor");

--- a/frontend/note.js
+++ b/frontend/note.js
@@ -1,0 +1,26 @@
+class Note {
+    #name;
+    #list_item;
+
+    constructor(name, notelist) {
+        this.#name = name;
+        this.#create_listentry(notelist);
+    }
+
+
+    get name() {
+        return this.#name;
+    }
+
+    #create_listentry(notelist) {
+        this.#list_item = document.createElement("li");
+        notelist.element.appendChild(this.#list_item);
+
+        this.#list_item.textContent = this.#name;
+        this.#list_item.addEventListener('click', async () => {
+            console.log("ToDo: activate");
+        }, false);
+    }
+}
+
+export { Note }

--- a/frontend/notelist.js
+++ b/frontend/notelist.js
@@ -1,0 +1,42 @@
+import { Note } from "./note.js"
+
+class NoteList {
+
+    #provider
+    #element;
+    #notes;
+
+    constructor(provider, element) {
+        this.#provider = provider;
+        this.#element = element;
+
+        this.#update();
+    }
+
+    async #update() {
+        this.#element.innerHTML = "";
+        this.#notes = new Map();
+
+        const notes = await this.#provider.list();
+        for (const name of notes) {
+            await this.#add(name);
+        }
+    }
+
+    async #add(name) {
+        const text = await this.#provider.read(name);
+        const tags = await this.#provider.read_tags(name);
+        const note = new Note(name, this);
+    }
+
+    get element() {
+        return this.#element;
+    }
+
+    async add_new() {
+        const name = await this.#provider.create();
+        this.#add(name);
+    }
+}
+
+export { NoteList }

--- a/frontend/noteprovider.js
+++ b/frontend/noteprovider.js
@@ -1,0 +1,117 @@
+
+/**
+ * This class documents the NoteProvider interface.
+ */
+class NoteProvider {
+
+    /**
+     * Returns a list of the names of all notes.
+     * 
+     * @returns {String[]} List containing the names of all notes.
+     */
+    async list() {
+        throw new Error("Not implementd");
+    }
+
+    /**
+     * Returns the contents of a note.
+     * 
+     * @param {String} name Name of the the note.
+     * @returns {String} contents of the note
+     * @throws {Error} unknown note
+     */
+    async read(name) {
+        throw new Error("Not implementd");
+    }
+
+    /**
+     * Creates a new note and returns it's name.
+     * 
+     * @returns {String} Name of the newly created note.
+     */
+    async create() {
+        throw new Error("Not implementd");
+    }
+
+    /**
+     * Renames an existing note.
+     * 
+     * @param {String} old_name Name of an existing note
+     * @param {String} new_name New name of the note
+     * @throws {Error} unknown note
+     * @throws {Error} there is already a note with the new name
+     */
+    async rename(old_name, new_name) {
+        throw new Error("Not implementd");
+    }
+
+    /**
+     * Writes the contents of an existing note.
+     * 
+     * @param {String} name Name of the note 
+     * @param {String} content New contents of the note
+     * @throws {Error} unknown note
+     */
+    async write(name, content) {
+        throw new Error("Not implementd");
+    }    
+
+    /**
+     * Removes an existing note.
+     * 
+     * Note that this method does not fail, if
+     * the note does not exist.
+     * 
+     * @param {String} name 
+     */
+    async remove(name) {
+        throw new Error("Not implementd");
+    }
+
+    /**
+     * Returns all tags of an existing note. 
+     * 
+     * @param {String} name name of then note
+     * @returns {String[]} tags of the note
+     * @throws {Error} unknown note
+     */
+    async read_tags(name) {
+        throw new Error("Not implementd");
+    }
+
+    /**
+     * Writes (replaces) tht tags of an existing note
+     * 
+     * @param {String} name name of the note
+     * @param {String[]} tags tags of the note
+     * @throws {Error} unknown note
+     */
+    async write_tags(name, tags) {
+        throw new Error("Not implementd");
+    }
+
+    /**
+     * Takes a screenshot and returns its filename.
+     * 
+     * @param {String} name name of the note associated with the screenshot
+     * @returns {String} filename of the screenshot (relative to the note's directory)
+     * @throws {Error} unknown note
+     * @throws {Error} screenshot command failed
+     */
+    async take_screenshot(name) {
+        throw new Error("Not implemented");
+    }
+
+    /**
+     * Opens the note directory in a file browser.
+     * 
+     * @param {String} name name of the note associated with the screenshot
+     * @throws {Error} unknown note
+     */
+    async open_note_directory(name) {
+        throw new Error("Not implemented");
+    }
+}
+
+
+export { NoteProvider }

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -60,16 +60,6 @@ body {
 }
 
 
-#content {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: nowrap;
-}
-
-#content > div {
-  flex: 1;
-}
-
 .controls {
   display: flex;
   flex-direction: row;
@@ -81,6 +71,20 @@ body {
 #filter {
   min-width: 100px;
   flex: 100%;
+}
+
+#notelist {
+  list-style: none;
+  padding-left: 5px;
+  padding-right: 5px;
+}
+
+#notelist > li.active {
+  font-weight: bold;
+}
+
+#notelist > li:hover {
+  background-color: #e0e0e0;
 }
 
 .hidden {
@@ -96,7 +100,45 @@ body {
   padding: 5px;
 }
 
-h1 {
+#settings h1 {
   font-weight: bold;
 }
 
+.toolbar {
+  display: flex;
+  flex-direction: row;
+  gap: 5px;
+  padding: 5px;
+}
+
+.toolbar > input {
+  flex: 100%;
+}
+
+.toolbar .button {
+  border: 1px solid #b0b0b0;
+  border-radius: 25%;
+  width: 20px;
+  height: 20px;  
+  line-height: 20px;
+  vertical-align: middle;
+  text-align: center;
+  padding-left:3px;
+  padding-right:3px;
+}
+
+.toolbar > .spacer {
+  width: 10px;
+}
+
+.toolbar .button:hover {
+  background-color: #e0e0e0;
+}
+
+.toolbar > label {
+  padding: 1px;
+}
+
+.toolbar .lni {
+  line-height: inherit;
+}

--- a/index.html
+++ b/index.html
@@ -41,6 +41,20 @@
     </div>
     <div id="slider" data-slider-target="sidebar" class="slider"></div>
     <div id="content">
+      <div class="toolbar">
+        <label class="lni lni-pencil"></label>
+        <input type="text" />
+        <div class="button"><i class="lni lni-camera"></i></div>
+        <div class="button"><i class="lni lni-folder"></i></div>
+        <div class="button"><i class="lni lni-save"></i></div>
+        <div class="spacer"></div>
+        <div class="button"><i class="lni lni-trash-can"></i></div>
+      </div>
+      <div class="toolbar">
+        <label class="lni lni-tag"></label>
+        <input type="text" />
+      </div>
+      <hr/>
       <div id="editor"></div>
       <!-- <div id="view"></div> -->
     </div>  


### PR DESCRIPTION
This PR allows to add new notes via frontend. Therefore the "Add" icon in the titlebar is used. A basic editor view is provided to give a glimpse idea of the functionality (no function added yet).

Note that no backend functionality is provided. A fake is used to simulate the basic behavior. The backend API is taken from [note.js](https://github.com/falk-werner/note.js). It is documented in the `NoteProvider` class.

Also note that the `Note` and `NoteList` classes are taken from [note.js](https://github.com/falk-werner/note.js). Only be required basics are taken by now. Maybe `note.js` and `note.rs` can share the same frontend in the future.