### PR TITLE
Add vulnerability scan action

### DIFF
--- a/.github/workflows/vulnerability-scan.yaml
+++ b/.github/workflows/vulnerability-scan.yaml
@@ -1,0 +1,19 @@
+name: Vulnerability-Scan
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 5'
+
+jobs:
+  audit:
+    name: Audit packages
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Audit packages
+        run: npm audit --audit-level low


### PR DESCRIPTION
 Scan with npm for vulnerabilities
-  every friday on midnight 
- on every push for PRs
- on push on main

The vulnerability severity is currently set to low so every vulnerability with low or higher severity lets the scan exit with code 1.