### PR TITLE
Feature: Allow to filter notes

### DIFF
--- a/frontend/editor.js
+++ b/frontend/editor.js
@@ -63,17 +63,17 @@ class Editor {
     }
 
     async set_note(note) {
-        this.#save();
+        await this.#save();
         this.#active_note = note;
         this.#title.value = note.name;
         this.#tags.value = note.tags.join(" ");
         
-        this.#set_content(await note.get_content());
+        this.#set_content(note.content);
     }
 
-    #save() {
+    async #save() {
         if (this.#active_note) {
-            this.#active_note.save(
+            await this.#active_note.save(
                 this.#title.value,
                 this.#editor.state.doc.toString(),
                 this.#tags.value.split(" "));

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -16,7 +16,8 @@ const editor = new Editor();
 
 const noteProvider = new FakeNoteProvider();
 const notelist_element = document.querySelector("#notelist");
-const notelist = new NoteList(noteProvider, notelist_element, editor);
+const filter_element = document.querySelector('#filter');
+const notelist = new NoteList(noteProvider, notelist_element, filter_element, editor);
 document.querySelector("#add-note").addEventListener("click", async () => {
   notelist.add_new();
 })

--- a/frontend/note.js
+++ b/frontend/note.js
@@ -76,7 +76,7 @@ class Note {
 
     applyFilter(filter) {
         const name = this.#name.toLowerCase();
-        const content = this.#name.toLowerCase();
+        const content = this.#content.toLowerCase();
         if ((name.includes(filter)) || (content.includes(filter))) {
             this.#list_item.classList.remove('hidden');
         }

--- a/frontend/note.js
+++ b/frontend/note.js
@@ -1,13 +1,15 @@
 class Note {
     #name;
+    #content;
     #tags;
     #provider;
     #editor;
     #list_item;
     #notelist
 
-    constructor(name, tags, provider, notelist, editor) {
+    constructor(name, content, tags, provider, notelist, editor) {
         this.#name = name;
+        this.#content = content;
         this.#tags = tags;
         this.#provider = provider;
         this.#editor = editor;
@@ -24,8 +26,8 @@ class Note {
         return this.#tags;
     }
 
-    async get_content() {
-        return await this.#provider.read(this.#name);
+    get content() {
+        return this.#content;
     }
 
     #create_listentry() {
@@ -49,13 +51,17 @@ class Note {
     }
 
     async save(name, content, tags) {
-        if (name != this.name) {
+        if (name != this.#name) {
             await this.#provider.rename(this.#name, name);
             this.#list_item.textContent = name;
             this.#notelist.rename(this.#name, name);
             this.#name = name;
         }
-        this.#provider.write(this.#name, content);
+
+        if (content != this.#content) {
+            this.#content = content;
+            this.#provider.write(this.#name, content);
+        }
 
         this.#tags = tags;
         this.#provider.write_tags(this.#name, tags);
@@ -66,6 +72,17 @@ class Note {
         this.#list_item.remove();
         this.#editor.remove();
         this.#notelist.remove(this);
+    }
+
+    applyFilter(filter) {
+        const name = this.#name.toLowerCase();
+        const content = this.#name.toLowerCase();
+        if ((name.includes(filter)) || (content.includes(filter))) {
+            this.#list_item.classList.remove('hidden');
+        }
+        else {
+            this.#list_item.classList.add('hidden');
+        }
     }
 }
 

--- a/frontend/notelist.js
+++ b/frontend/notelist.js
@@ -4,16 +4,19 @@ class NoteList {
 
     #provider
     #element;
+    #filter;
     #editor;
     #notes;
     #active_note;
 
-    constructor(provider, element, editor) {
+    constructor(provider, element, filter, editor) {
         this.#provider = provider;
         this.#element = element;
+        this.#filter = filter;
         this.#editor = editor;
         this.#active_note = null;
 
+        this.#filter.addEventListener('input', () => this.applyFilter());
         this.#update();
     }
 
@@ -28,8 +31,9 @@ class NoteList {
     }
 
     async #add(name, activate) {
+        const content = await this.#provider.read(name);
         const tags = await this.#provider.read_tags(name);
-        const note = new Note(name, tags, this.#provider, this, this.#editor);
+        const note = new Note(name, content, tags, this.#provider, this, this.#editor);
         this.#notes.set(name, note);
         if ((!this.#active_note) || (activate)) {
             this.activate(note);
@@ -68,6 +72,13 @@ class NoteList {
             if (this.#notes.size > 0) {
                 this.activate(this.#notes.values().next().value);
             }
+        }
+    }
+
+    applyFilter() {
+        const filter = this.#filter.value.toLowerCase();
+        for(const note of this.#notes.values()) {
+            note.applyFilter(filter);
         }
     }
 }


### PR DESCRIPTION
This PR allows to filter notes. The implementation follows the one from [note.py](https://github.com/falk-werner/note.py) and [note.js](https://github.com/falk-werner/note.js):
- filter is not case sensitive
- filter is applied on the note's name
- filter is applied on the note's contents

Therefore, the contents of all notes is cached in the frontend (just like [note.js](https://github.com/falk-werner/note.js) does) to prevent unnecessary backend and filesystem operations. This PR also introduces some `await` calls in the `editor` module to force order of operations. 