### PR TITLE
Feature: Allow to switch between view and edit mode

### DIFF
--- a/frontend/editor.js
+++ b/frontend/editor.js
@@ -13,12 +13,19 @@ class Editor {
     #tags
     #active_note
     #editor
+    #content_element
+    #view
     #remove_dialog
+    #mode
+    #mode_change_handler
 
     constructor() {
         this.#active_note = null;
         this.#title = document.querySelector("#editor-title");
         this.#tags = document.querySelector("#editor-tags");
+        this.#view = document.querySelector("#view");
+        this.#content_element = document.querySelector("#content");
+        this.#mode_change_handler = () => {};
 
         document.querySelector("#editor-save").addEventListener("click", () => {
             this.#save();
@@ -49,17 +56,41 @@ class Editor {
             parent: editor_element
         });
 
-        /*
-        editor.dom.addEventListener('input', async () => {
-        const text = editor.state.doc.toString();
-        const html = marked.parse(text, {
-            pedantic: false,
-            gfm: true
-        });
-        document.querySelector("#view").innerHTML = html;
-        });
-        */
+        this.mode = "view";
+    }
 
+    get mode() {
+        return this.#mode;
+    }
+
+    set mode(new_mode) {
+        switch (new_mode) {
+            case "edit":
+                this.#mode = "edit";
+                this.#view.classList.add("hidden");
+                this.#content_element.classList.remove("hidden");
+                break;
+            case "view":
+                // fall-through
+            default:
+                this.#mode = "view";
+                this.#view.classList.remove("hidden");
+                this.#content_element.classList.add("hidden");
+
+                const content = this.#editor.state.doc.toString();
+                const html = marked.parse(content, {
+                    pedantic: false,
+                    gfm: true
+                });
+                this.#view.innerHTML = html;        
+                break;
+        }
+
+        this.#mode_change_handler();
+    }
+
+    set mode_change_handler(handler) {
+        this.#mode_change_handler = handler;
     }
 
     async set_note(note) {
@@ -86,6 +117,12 @@ class Editor {
             to: this.#editor.state.doc.length,
             insert: content
         }]});
+
+        const html = marked.parse(content, {
+            pedantic: false,
+            gfm: true
+        });
+        this.#view.innerHTML = html;
     }
 
     remove() {

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -14,6 +14,21 @@ init_settings();
 slider_attach(document.querySelector("#slider"));
 
 const editor = new Editor();
+editor.mode_change_handler = () => {
+  const icon = document.querySelector("#toggle-mode > i");
+  if (editor.mode == "edit") {
+      icon.classList.add("lni-pencil");
+      icon.classList.remove("lni-eye");
+  }
+  else {
+      icon.classList.add("lni-eye");
+      icon.classList.remove("lni-pencil");
+  }
+};
+document.querySelector("#toggle-mode").addEventListener("click", () => {
+  editor.mode = (editor.mode == "edit") ? "view" : "edit";
+});
+
 
 const noteProvider = new FakeNoteProvider();
 

--- a/frontend/notelist.js
+++ b/frontend/notelist.js
@@ -58,6 +58,7 @@ class NoteList {
     async add_new() {
         const name = await this.#provider.create();
         this.#add(name, true);
+        this.#editor.mode = "edit";
     }
 
     rename(old_name, new_name) {

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -172,3 +172,34 @@ dialog .controls {
 #taglist > div.active {
   background-color: #b0d0f0;
 }
+
+#view {
+  padding-left: 5px;
+  padding-right: 5px;
+}
+
+#view pre {
+  background-color: #e0e0e0;
+}
+
+#view code {
+  font-family: monospace;
+  background-color: #e0e0e0;
+}
+
+#view table {
+  border-collapse: collapse;
+}
+
+#view table, #view th, #view td {
+  border: 1px solid black;
+}
+
+#view th {
+  background-color: black;
+  color: white;
+}
+
+#view tr:nth-child(2n) {
+  background-color: #e0e0e0;
+}

--- a/index.html
+++ b/index.html
@@ -10,6 +10,9 @@
     <div class="titlebar-button" id="add-note">
       <i class="lni lni-empty-file"></i>
     </div>
+    <div class="titlebar-button" id="toggle-mode">
+      <i class="lni lni-eye"></i>
+    </div>
     <div data-tauri-drag-region style="line-height: 30px; flex: 100%; text-align: center;">
       note.rs
     </div>
@@ -41,7 +44,7 @@
       <ul id="notelist"></ul>
     </div>
     <div id="slider" data-slider-target="sidebar" class="slider"></div>
-    <div id="content">
+    <div id="content" class="hidden">
       <div class="toolbar">
         <label class="lni lni-pencil"></label>
         <input type="text" id="editor-title"/>
@@ -57,8 +60,8 @@
       </div>
       <hr/>
       <div id="editor"></div>
-      <!-- <div id="view"></div> -->
     </div>  
+    <div id="view"></div>
   </div>
 
   <div id="settings" class="hidden">    


### PR DESCRIPTION
This PR introduces `view` mode according to [note.py`s](https://github.com/falk-werner/note.py) implementation.

The user can toggle between `view` and `edit` mode using the icon in the title bar. Note that `view` mode is default, since it is expected to be the most common use case. Some basic CSS styles are added, but styling is not in focus here.

With this PR, we only have `view` and `edit` mode. We might add an "edit with preview" mode in future, but this is not part of this pull request. _(Note that the basics are just in place, but we need to learn more about Code Mirror before we get were we want.)_


Please note that our `index.html`, our styles and some JavaScript logic are a mess. I want to clean this up later, in a separate pull request. I also want to add accelerators (a.k.a. shortcuts) and tooltips for our icons. Maybe we need some welcome page when no note is present, settings should be editable and the info page should be filled. But these are all separate PRs in my opinion. Although, with this PR, we should have some minimal usable frontend so we can focus on backend functionality in the near future.