### PR TITLE
Feature: Add config file support

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -729,12 +729,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1586,7 +1580,7 @@ dependencies = [
  "serde_yaml",
  "tauri",
  "tauri-build",
- "tempdir",
+ "tempfile",
 ]
 
 [[package]]
@@ -2008,19 +2002,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -2066,21 +2047,6 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
-name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
@@ -2120,15 +2086,6 @@ name = "raw-window-handle"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
-]
 
 [[package]]
 name = "redox_syscall"
@@ -2193,15 +2150,6 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "rustc-demangle"
@@ -2851,16 +2799,6 @@ checksum = "5993dc129e544393574288923d1ec447c857f3f644187f4fbf7d9a875fbfc4fb"
 dependencies = [
  "embed-resource",
  "toml 0.7.8",
-]
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -729,6 +729,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1580,6 +1586,7 @@ dependencies = [
  "serde_yaml",
  "tauri",
  "tauri-build",
+ "tempdir",
 ]
 
 [[package]]
@@ -2001,6 +2008,19 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -2046,6 +2066,21 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
@@ -2085,6 +2120,15 @@ name = "raw-window-handle"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -2149,6 +2193,15 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -2798,6 +2851,16 @@ checksum = "5993dc129e544393574288923d1ec447c857f3f644187f4fbf7d9a875fbfc4fb"
 dependencies = [
  "embed-resource",
  "toml 0.7.8",
+]
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1147,6 +1147,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1565,8 +1574,10 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 name = "note-rs"
 version = "0.1.0"
 dependencies = [
+ "home",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tauri",
  "tauri-build",
 ]
@@ -2316,6 +2327,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1bf28c79a99f70ee1f1d83d10c875d2e70618417fda01ad1785e027579d9d38"
+dependencies = [
+ "indexmap 2.1.0",
+ "itoa 1.0.10",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serialize-to-javascript"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3062,6 +3086,12 @@ name = "unicode-segmentation"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
 
 [[package]]
 name = "url"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,3 +26,6 @@ home = "0.5.9"
 # If you use cargo directly instead of tauri's cli you can use this feature flag to switch between tauri's `dev` and `build` modes.
 # DO NOT REMOVE!!
 custom-protocol = [ "tauri/custom-protocol" ]
+
+[dev-dependencies]
+tempdir = "0.3.7"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,4 +28,4 @@ home = "0.5.9"
 custom-protocol = [ "tauri/custom-protocol" ]
 
 [dev-dependencies]
-tempdir = "0.3.7"
+tempfile = "3.9.0"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,6 +18,8 @@ tauri-build = { version = "1.5.0", features = [] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "1.5.3", features = [ "window-unminimize", "window-unmaximize", "window-maximize", "window-show", "window-minimize", "window-close", "window-start-dragging", "window-hide"] }
+serde_yaml = "0.9.30"
+home = "0.5.9"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem and the built-in dev server is disabled.

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -135,7 +135,7 @@ mod tests {
 
 use crate::Config;
 use crate::config::{get_home_dir};
-use tempdir::TempDir;
+use tempfile::tempdir;
 use std::fs;
 use std::path::{PathBuf};
 
@@ -167,7 +167,7 @@ fn load_config_from_file() {
 values:
   base_dir: '/path/to/notes'"##;
 
-    let temp_dir = TempDir::new("noters-test").unwrap();
+    let temp_dir = tempdir().unwrap();
     let config_path = temp_dir.path().join("config.yaml");
     fs::write(config_path.clone(), text).unwrap();
 
@@ -179,7 +179,7 @@ values:
 
 #[test]
 fn fail_to_load_non_existing_config_file() {
-    let temp_dir = TempDir::new("noters-test").unwrap();
+    let temp_dir = tempdir().unwrap();
     let config_path = temp_dir.path().join("config.yaml");
 
     let config = Config::from_file(config_path.as_path());
@@ -192,7 +192,7 @@ fn fail_to_load_non_existing_config_file() {
 fn fail_to_load_invalid_config_file() {
     let text = br##"\t this is not yaml"##;
 
-    let temp_dir = TempDir::new("noters-test").unwrap();
+    let temp_dir = tempdir().unwrap();
     let config_path = temp_dir.path().join("config.yaml");
     fs::write(config_path.clone(), text).unwrap();
 
@@ -209,7 +209,7 @@ fn fail_to_load_config_file_with_wrong_version() {
 values:
   base_dir: '/path/to/notes'"##;
 
-    let temp_dir = TempDir::new("noters-test").unwrap();
+    let temp_dir = tempdir().unwrap();
     let config_path = temp_dir.path().join("config.yaml");
     fs::write(config_path.clone(), text).unwrap();
 
@@ -221,7 +221,7 @@ values:
 
 #[test]
 fn save_config_file() {
-    let temp_dir = TempDir::new("noters-test").unwrap();
+    let temp_dir = tempdir().unwrap();
     let config_path = temp_dir.path().join("config.yaml");
 
     let config = Config::new(config_path.as_path());
@@ -235,7 +235,7 @@ fn save_config_file() {
 
 #[test]
 fn save_does_not_fail_if_config_file_cannot_be_written() {
-    let temp_dir = TempDir::new("noters-test").unwrap();
+    let temp_dir = tempdir().unwrap();
     let config_path = temp_dir.path().join("non-existing-dir").join("config.yaml");
 
     let config = Config::new(config_path.as_path());

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -1,0 +1,158 @@
+use serde::{Serialize, Deserialize};
+use home::{home_dir};
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use core::fmt::Display;
+
+const DEFAULT_CONFIG_FILENAME: &str = ".noters.yaml";
+
+pub struct Config {
+    filename: Box<Path>,
+    config_file: ConfigFile
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct ConfigFile {
+    meta: MetaInfo,
+    values: ConfigValues
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct MetaInfo {
+    version: u32
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct ConfigValues {
+    base_dir: String
+}
+
+fn get_home_dir() -> PathBuf {
+    home_dir().unwrap_or(PathBuf::from("."))
+}
+
+struct ConfigError {
+    message: String
+}
+
+impl ConfigError {
+    fn new(message: &str) -> Self {
+        ConfigError { message: message.into() }
+    }
+}
+
+impl<E: Display> From<E> for ConfigError {
+    fn from(value: E) -> Self {
+        ConfigError { message: value.to_string() }
+    }
+}
+
+impl Config {
+
+    /// Creates a new config with default values.
+    fn new() -> Self {
+        Config {
+            filename: get_home_dir().join(DEFAULT_CONFIG_FILENAME).as_path().into(),
+            config_file: { 
+                ConfigFile {
+                    meta: {
+                        MetaInfo { 
+                            version: 1
+                        }
+                    },
+                    values: { 
+                        ConfigValues {
+                            base_dir: String::from("{home}/.notes")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Loads the config from the default config file.
+    ///
+    /// The default config file is located at ~/.noters.yaml.
+    /// When the file does not exist, a default config is created and stored
+    /// at the default config file location.
+    pub fn from_default_file() -> Self {
+        let filename = get_home_dir().join(DEFAULT_CONFIG_FILENAME);
+
+        match Config::from_file(filename.as_path()) {
+            Ok(config) => config,
+            Err(error) => {
+                eprintln!("warning: failed to load config {:?}: {}", filename, error.message);
+                let config = Config::new();
+                config.save();
+                config
+            }
+        }
+    }
+
+    /// Try to load the config from a given path.
+    fn from_file(filename: &Path) -> Result<Self, ConfigError> {
+        let text = fs::read_to_string(filename)?;
+        let config_file = serde_yaml::from_str::<ConfigFile>(&text)?;
+        
+        if config_file.meta.version != 1 {
+            return Err(ConfigError::new("unknown file format (version mismatch)"));
+        }
+
+        Ok(Config { 
+            filename: filename.into(),
+            config_file: config_file
+        })
+    }
+
+    /// Returns the base path, where the notes are stored.
+    pub fn get_base_path(&self) -> PathBuf {
+        let home_dir = get_home_dir();
+        let base_dir = &self.config_file.values.base_dir;
+
+        PathBuf::from(base_dir.replace("{home}", &home_dir.to_string_lossy()))
+    }
+
+    /// Tries to save the configuration.
+    ///
+    /// Note that this function will not fail, even when the config file is not written.
+    /// This behavior is intended, since there is no good way to handle those errors.
+    /// At least, an error message is emitted.
+    fn save(&self) {
+        let text = serde_yaml::to_string(&self.config_file).unwrap();
+        if let Err(error) = fs::write(self.filename.as_ref(), text.as_bytes()) {
+            eprintln!("error: failed to save config: {:?}: {}", self.filename, error.to_string());
+        }
+        else {
+            eprintln!("info: saved config: {:?}", self.filename);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+use crate::Config;
+use crate::config::{get_home_dir};
+
+#[test]
+fn create_default_config() {
+    let config = Config::new();
+
+    assert_eq!(1, config.config_file.meta.version);
+    assert_eq!(".noters.yaml", config.filename.file_name().unwrap());
+    assert_eq!("{home}/.notes", config.config_file.values.base_dir);
+}
+
+#[test]
+fn get_base_path_resolves_home() {
+    let config = Config::new();
+
+    let expected = get_home_dir().join(".notes");
+    let actual = config.get_base_path();
+
+    assert_eq!(expected, actual);
+}
+
+
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,10 +2,15 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 use std::{fs::DirEntry, io::{Error, Result}, path::{Path, PathBuf}};
-use tauri::api::path::home_dir;
+
+mod config;
+use config::{Config};
 
 fn main() {
+  let config = Config::from_default_file();
+
   tauri::Builder::default()
+    .manage(config)
     .invoke_handler(tauri::generate_handler![
       list
       ])
@@ -17,13 +22,14 @@ fn main() {
 /// 
 /// list all directories in the base directory that have a `README.md` file inside
 #[tauri::command]
-async fn list() -> Vec<String> {
-  let base_path = Path::new(home_dir().unwrap().as_path()).join(".notes");
+fn list(config: tauri::State<'_, Config>) -> Vec<String> {
+  let base_path = config.get_base_path().join(".notes");
   match get_note_names(base_path) {
     Ok(note_names) => return note_names,
     Err(e) => error_handling(e.to_string())
   }
-  return Vec::<String>::new();
+
+  Vec::<String>::new()
 }
 
 /// list all directories in `base_path` that have a `README.md` file inside

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -22,14 +22,14 @@ fn main() {
 /// 
 /// list all directories in the base directory that have a `README.md` file inside
 #[tauri::command]
-fn list(config: tauri::State<'_, Config>) -> Vec<String> {
+async fn list(config: tauri::State<'_, Config>) -> std::result::Result<Vec<String>, String> {
   let base_path = config.get_base_path().join(".notes");
   match get_note_names(base_path) {
-    Ok(note_names) => return note_names,
+    Ok(note_names) => return Ok(note_names),
     Err(e) => error_handling(e.to_string())
   }
 
-  Vec::<String>::new()
+  Ok(Vec::<String>::new())
 }
 
 /// list all directories in `base_path` that have a `README.md` file inside


### PR DESCRIPTION
This PR adds basic support of a config file.
The first implementations only provides the base path of the notes, more options will be implemented later, e.g. to specify styles for the notes. The config file is located at `~/.noters.yaml` and will be created when it's not present at startup.