### PR TITLE
Feature: Allow to open a note directory in file explorer

### DIFF
--- a/frontend/editor.js
+++ b/frontend/editor.js
@@ -40,8 +40,14 @@ class Editor {
         document.querySelector("#editor-screenshot").addEventListener("click", () => {
             notImplementedDialog.showModal();
         });
-        document.querySelector("#editor-open-folder").addEventListener("click", () => {
-            notImplementedDialog.showModal();
+
+        document.querySelector("#editor-open-folder").addEventListener("click", async () => {
+            try {
+                await this.#active_note.open_note_directory();
+            }
+            catch (ex) {
+                notImplementedDialog.showModal();
+            }
         });
         
 

--- a/frontend/note.js
+++ b/frontend/note.js
@@ -94,6 +94,10 @@ class Note {
         this.#notelist.remove(this);
     }
 
+    async open_note_directory() {
+        await this.#provider.open_note_directory(this.#name);
+    }
+
     #filter_by_tags(tags) {
         if (tags.length == 0) {
             return true;

--- a/frontend/taurinoteprovider.js
+++ b/frontend/taurinoteprovider.js
@@ -41,7 +41,11 @@ class TauriNoteProvider extends NoteProvider {
             name: name,
             tags: tags
         });
-    }    
+    }
+
+    async open_note_directory(name) {
+        await tauri.invoke("open_note_directory", {name: name});
+    }
 }
 
 export { TauriNoteProvider }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -174,6 +174,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c48f0051a4b4c5e0b6d365cd04af53aeaa209e3cc15ec2cdb69e73cc87fbd0dc"
 dependencies = [
  "memchr",
+ "regex-automata 0.4.3",
  "serde",
 ]
 
@@ -1571,10 +1572,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "normpath"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec60c60a693226186f5d6edf073232bfb6464ed97eb22cf3b01c1e8198fd97f5"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "note-rs"
 version = "0.1.0"
 dependencies = [
  "home",
+ "opener",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1675,6 +1686,17 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "opener"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c62dcb6174f9cb326eac248f07e955d5d559c272730b6c03e396b443b562788"
+dependencies = [
+ "bstr",
+ "normpath",
+ "winapi",
+]
 
 [[package]]
 name = "overload"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "1.5.3", features = [ "window-unminimize", "window-unmaximize", "window-maximize", "window-show", "window-minimize", "window-close", "window-start-dragging", "window-hide"] }
 serde_yaml = "0.9.30"
 home = "0.5.9"
+opener = "0.6.1"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem and the built-in dev server is disabled.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -23,7 +23,8 @@ fn main() {
       write,
       remove,
       read_tags,
-      write_tags
+      write_tags,
+      open_note_directory
       ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");
@@ -70,4 +71,9 @@ async fn read_tags(note: tauri::State<'_, Note>, name: &str) -> NoteResult<Vec<S
 #[tauri::command]
 async fn write_tags(note: tauri::State<'_, Note>, name: &str, tags: Vec<String>) -> NoteResult<()> {
   note.write_tags(name, &tags)
+}
+
+#[tauri::command]
+async fn open_note_directory(note: tauri::State<'_, Note>, name: &str) -> NoteResult<()> {
+  note.open_note_direcotry(name)
 }

--- a/src-tauri/src/note.rs
+++ b/src-tauri/src/note.rs
@@ -2,6 +2,9 @@ use std::{fs, fs::DirEntry, path::{Path, PathBuf}};
 use crate::config::{Config};
 use crate::noteerror::{NoteError, NoteResult};
 
+
+use opener;
+
 pub struct Note {
     config: Config
 }
@@ -97,6 +100,12 @@ impl Note {
       let mut path = self.config.get_base_path();
       path.push(name);
       Ok(path)
+    }
+
+    pub fn open_note_direcotry(&self, name: &str) -> NoteResult<()> {
+      let path = self.get_note_path(name)?;
+      opener::open(path.as_path())?;
+      Ok(())
     }
 }
 


### PR DESCRIPTION
This PR allows to open a note's directory in file explorer. It uses the crate [opener](https://crates.io/crates/opener) to do so.