### PR TITLE
Enable line wrapping

### DIFF
--- a/frontend/editor.js
+++ b/frontend/editor.js
@@ -63,6 +63,7 @@ class Editor {
         this.#editor = new EditorView({
             extensions: [
                 basicSetup,
+                EditorView.lineWrapping,
                 language.of(markdown())
             ],
             doc: "",


### PR DESCRIPTION
This PR prevents editor view from growing behind the windows width (editor icons disappeared).