### PR TITLE
Feature: Settings Page

### DIFF
--- a/frontend/editor.js
+++ b/frontend/editor.js
@@ -29,7 +29,7 @@ class Editor {
         this.#mode_change_handler = () => {};
 
         document.querySelector("#editor-save").addEventListener("click", () => {
-            this.#save();
+            this.save();
         });
 
         this.#remove_dialog = new RemoveDialog(document.querySelector("#remove-dialog"));
@@ -110,7 +110,7 @@ class Editor {
     }
 
     async set_note(note) {
-        await this.#save();
+        await this.save();
         this.#active_note = note;
         this.#title.value = note.name;
         this.#tags.value = note.tags.join(" ");
@@ -118,7 +118,7 @@ class Editor {
         this.#set_content(note.content);
     }
 
-    async #save() {
+    async save() {
         if (this.#active_note) {
             await this.#active_note.save(
                 this.#title.value,

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -9,9 +9,10 @@ import { TauriNoteProvider } from "./taurinoteprovider.js"
 import { NoteList } from "./notelist.js"
 import { Editor } from "./editor.js"
 import { TagList } from "./taglist.js"
+import { TauriSettingsProvider } from "./taurisettingsprovider.js"
 
 init_titlebar();
-init_settings();
+init_settings(new TauriSettingsProvider());
 init_info();
 slider_attach(document.querySelector("#slider"));
 

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -11,7 +11,6 @@ import { Editor } from "./editor.js"
 import { TagList } from "./taglist.js"
 import { TauriSettingsProvider } from "./taurisettingsprovider.js"
 
-init_titlebar();
 init_info();
 slider_attach(document.querySelector("#slider"));
 
@@ -43,6 +42,10 @@ const notelist = new NoteList(noteProvider, notelist_element, filter_element, ta
 document.querySelector("#add-note").addEventListener("click", async () => {
   notelist.add_new();
 })
+
+init_titlebar(async () => {
+  await editor.save();
+});
 
 init_settings(new TauriSettingsProvider(), () => {
   editor.remove();

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -12,7 +12,6 @@ import { TagList } from "./taglist.js"
 import { TauriSettingsProvider } from "./taurisettingsprovider.js"
 
 init_titlebar();
-init_settings(new TauriSettingsProvider());
 init_info();
 slider_attach(document.querySelector("#slider"));
 
@@ -44,6 +43,13 @@ const notelist = new NoteList(noteProvider, notelist_element, filter_element, ta
 document.querySelector("#add-note").addEventListener("click", async () => {
   notelist.add_new();
 })
+
+init_settings(new TauriSettingsProvider(), () => {
+  editor.remove();
+  notelist.update();
+  taglist.update();
+});
+
 
 
 

--- a/frontend/notelist.js
+++ b/frontend/notelist.js
@@ -27,7 +27,10 @@ class NoteList {
         this.#element.innerHTML = "";
         this.#notes = new Map();
 
-        const notes = await this.#provider.list();
+        const notes = (await this.#provider.list()).sort((a, b) => {
+            return a.toLowerCase().localeCompare(b.toLowerCase());
+        });
+        
         for (const name of notes) {
             try {
                 await this.#add(name);

--- a/frontend/notelist.js
+++ b/frontend/notelist.js
@@ -20,26 +20,41 @@ class NoteList {
 
         this.#filter.addEventListener('input', () => this.apply_filter());
         this.#taglist.change_handler = () => { this.apply_filter() };
-        this.#update();
     }
 
-    async #update() {
+    async update() {
+        this.#active_note = null;
         this.#element.innerHTML = "";
         this.#notes = new Map();
 
         const notes = await this.#provider.list();
         for (const name of notes) {
-            await this.#add(name);
+            try {
+                await this.#add(name);
+            }
+            catch (ex) {
+                console.warn("failed to load note", name, ex);
+            }
         }
     }
 
     async #add(name, activate) {
         const content = await this.#provider.read(name);
-        const tags = await this.#provider.read_tags(name);
+        const tags = await this.#read_tags(name);
         const note = new Note(name, content, tags, this.#provider, this, this.#taglist, this.#editor);
         this.#notes.set(name, note);
         if ((!this.#active_note) || (activate)) {
             this.activate(note);
+        }
+    }
+
+    async #read_tags(name) {
+        try {
+            return await this.#provider.read_tags(name);
+        }
+        catch (ex) {
+            console.warn("failed to read tags", name, ex);
+            return [];
         }
     }
 

--- a/frontend/settings.js
+++ b/frontend/settings.js
@@ -1,4 +1,3 @@
-
 const get_all_css_rules = () => {
     const result = new Map();
     const stylesheets = document.styleSheets;
@@ -19,12 +18,105 @@ const get_rule = (name) => {
 
 }
 
-const init_settings = () => {
+function handleKnownSetting(id, value) {
+    console.log("handle known", id);
+    switch (id) {
+        case "view.titlebar.color":
+            setColor(".titlebar", value);
+            break;
+        default:
+            break;
+    }
+}
+
+function setColor(ruleName, color) {
+    const rule = get_rule(ruleName);
+    rule.style.background=color;
+}
+
+
+class SettingsPage
+{
+    #provider;
+
+    constructor(provider) {
+        this.#provider = provider;
+        this.init();
+    }
+
+    async init() {
+        const element = document.querySelector("#settings_items");
+
+        const settings = await this.#provider.readAll();
+        for(const setting of settings) {
+            this.addSetting(element, setting);
+            handleKnownSetting(setting.id, setting.value);
+        }
+    }
+
+    addSetting(element, setting) {
+        switch (setting.data_type) {
+            case "string":
+                this.addStringSetting(element, setting);
+                break;
+            case "color":
+                this.addColorSetting(element, setting);
+                break;
+            default:
+                console.warn("setting: unknown data_type: ", setting);
+                break;
+        }
+    }
+
+    addGenericSetting(element, setting, inputType) {
+        const div = document.createElement("div");
+        element.appendChild(div);
+
+        const label = document.createElement("span");
+        div.appendChild(label);
+        label.textContent = setting.name;
+
+        const input = document.createElement("input");
+        div.appendChild(input);
+        input.type = inputType;
+        input.value = setting.value;
+
+        input.addEventListener("change", () => {
+            console.log("change");
+            this.write(setting.id, input.value);
+        });
+    }
+
+    addStringSetting(element, setting) {
+        this.addGenericSetting(element, setting, "text");
+    }
+
+    addColorSetting(element, setting) {
+        this.addGenericSetting(element, setting, "color");
+    }
+
+    async write(id, value) {
+        console.log("write", id, value);
+        try {
+            await this.#provider.write(id, value);
+            handleKnownSetting(id, value);
+        }
+        catch (ex) {
+            console.error("failed to write setting", id, ex);
+        }
+    }
+}
+
+const init_settings = (provider) => {
+    /*
     const titlebar = document.querySelector("#settings_titlebar");
     titlebar.addEventListener("input", () => {
         const rule = get_rule(".titlebar");
         rule.style.background=titlebar.value;
     });
+    */
+
+    new SettingsPage(provider);
 };
 
 export { init_settings }

--- a/frontend/settingsprovider.js
+++ b/frontend/settingsprovider.js
@@ -1,0 +1,24 @@
+class SettingsProvider {
+
+    /**
+     * Returns a list of all settings.
+     * 
+     * @returns {Setting[]} List of settings.
+     */
+    async readAll() {
+        throw new Error("Not implemented");
+    }
+
+    /**
+     * Sets the value of single setting.
+     * 
+     * @param {*} name name of the setting
+     * @param {*} value new value of the setting
+     * @throws {Error} unknown setting
+     */
+    async write(name, value) {
+        throw new Error("Not implemented");
+    }
+}
+
+export { SettingsProvider }

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -205,7 +205,7 @@ dialog .controls {
   background-color: #e0e0e0;
 }
 
-#info {
+#info, #settings {
   display: flex;
   flex-direction: row;
   gap: 10px;
@@ -241,4 +241,19 @@ dialog .controls {
   align-self: stretch;
   height: 100%;
   border: 1px solid #e0e0e0;
+}
+
+#settings_items > div {
+  margin-bottom: 1em;
+}
+
+#settings_items span {
+  display: block;
+}
+
+#settings_items input {
+  display: block;
+  width: 100%;
+  min-width:200px;
+  margin-left: 1em;
 }

--- a/frontend/taglist.js
+++ b/frontend/taglist.js
@@ -11,8 +11,6 @@ class TagList {
         this.#provider = provider;        
         this.#tags = new Map();
         this.#change_handler = null;
-
-        this.update();
     }
 
     get active_tags() {
@@ -33,13 +31,18 @@ class TagList {
        const new_tags = new Map();
         const notes = await this.#provider.list();
         for(const note of notes) {
-            const tags = await this.#provider.read_tags(note);
-            for(let tag of tags) {
-                tag = tag.toLowerCase();
-                if (!new_tags.has(tag)) {
-                    const active = this.#tags.has(tag) ? this.#tags.get(tag) : false;
-                    new_tags.set(tag, active);
+            try {
+                const tags = await this.#provider.read_tags(note);
+                for(let tag of tags) {
+                    tag = tag.toLowerCase();
+                    if (!new_tags.has(tag)) {
+                        const active = this.#tags.has(tag) ? this.#tags.get(tag) : false;
+                        new_tags.set(tag, active);
+                    }
                 }
+            }
+            catch (ex) {
+                console.warn("failed to get tags", note, ex);
             }
         }
         this.#tags = new_tags;

--- a/frontend/taurisettingsprovider.js
+++ b/frontend/taurisettingsprovider.js
@@ -1,0 +1,19 @@
+import { tauri } from "@tauri-apps/api";
+import { SettingsProvider } from "./settingsprovider";
+
+class TauriSettingsProvider extends SettingsProvider {
+
+    async readAll() {
+        return await tauri.invoke("read_all_settings");
+    }
+
+    async write(name, value) {
+        return await tauri.invoke("write_setting", {
+            name: name,
+            value: value
+        });
+    }
+
+}
+
+export { TauriSettingsProvider }

--- a/frontend/titlebar.js
+++ b/frontend/titlebar.js
@@ -1,6 +1,6 @@
 import { appWindow } from '@tauri-apps/api/window'
 
-const init_titlebar = function() {
+const init_titlebar = function(onclose) {
     const settings = document.querySelector("#titlebar-settings");
     settings.addEventListener('click', () => {
         document.querySelector("#main").classList.add("hidden");
@@ -21,7 +21,15 @@ const init_titlebar = function() {
     maximize.addEventListener('click', () => appWindow.toggleMaximize());
 
     const close = document.querySelector('#titlebar-close');
-    close.addEventListener('click', () => appWindow.close());
+    close.addEventListener('click', async () => {
+        try {
+            await onclose();
+        }
+        catch (ex) {
+            console.error("onclose handler failed", ex);
+        }
+        appWindow.close();
+    });
 
     const nav_main = document.querySelectorAll(".nav-main");
     nav_main.forEach((item) => {

--- a/index.html
+++ b/index.html
@@ -69,10 +69,10 @@
   </div>
 
   <div id="settings" class="hidden">    
-    <h1><i class="lni lni-arrow-left-circle nav-main"></i> Settings</h1>
-    <h2>Color Settings</h2>
+    <div><h1><i class="lni lni-arrow-left-circle nav-main"></i></h1></div>
     <div>
-      <span>Title Bar:</span><input id="settings_titlebar" type="color" value="#b0b0b0" />
+      <h1>Settings</h1>
+      <div id="settings_items"></div>
     </div>
   </div>
 

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -29,6 +29,14 @@ struct ConfigValues {
     base_dir: String
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ConfigValue {
+    pub name: String,
+    pub data_type: String,
+    pub value: String
+}
+
+
 fn get_home_dir() -> PathBuf {
     home_dir().unwrap_or(PathBuf::from("."))
 }
@@ -96,6 +104,20 @@ impl Config {
         let base_dir = &self.config_file.values.base_dir;
 
         PathBuf::from(base_dir.replace("{home}", &home_dir.to_string_lossy()))
+    }
+
+    pub fn read_all(&self) -> Vec<ConfigValue> {
+        vec!(
+            ConfigValue {
+                name: String::from("base_path"),
+                data_type: String::from("string"),
+                value: String::from(&self.config_file.values.base_dir)
+            }
+        )
+    }
+
+    pub fn write(&mut self, _name: &str, _value: &str) {
+        self.save();
     }
 
     /// Tries to save the configuration.

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -26,7 +26,14 @@ struct MetaInfo {
 
 #[derive(Serialize, Deserialize, Debug)]
 struct ConfigValues {
-    base_dir: String
+    base_dir: String,
+
+    #[serde(default = "default_screenshot_command")]
+    screenshot_command: String,
+
+    #[serde(default = "default_titlebar_color")]
+    titlebar_color: String,
+
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -35,6 +42,14 @@ pub struct ConfigValue {
     pub name: String,
     pub data_type: String,
     pub value: String
+}
+
+fn default_screenshot_command() -> String {
+    String::from("gnome-screenshot -a {filename}")
+}
+
+fn default_titlebar_color() -> String {
+    String::from("#b0b0b0")   
 }
 
 impl ConfigValue {
@@ -68,7 +83,9 @@ impl Config {
                     },
                     values: { 
                         ConfigValues {
-                            base_dir: String::from("{home}/.notes")
+                            base_dir: String::from("{home}/.notes"),
+                            screenshot_command: default_screenshot_command(),
+                            titlebar_color: default_titlebar_color(),
                         }
                     }
                 }
@@ -121,12 +138,19 @@ impl Config {
     pub fn read_all(&self) -> Vec<ConfigValue> {
         vec!(
             ConfigValue::new("notes.path", "Notes Directory","string", &self.config_file.values.base_dir),
-            ConfigValue::new("screenshot.command", "Screenshot Command","string", "gnome-screenshot -a {filename}"),
-            ConfigValue::new("view.titlebar.color", "Titlebar Color","color", "#b0b0b0"),
+            ConfigValue::new("screenshot.command", "Screenshot Command","string", &self.config_file.values.screenshot_command),
+            ConfigValue::new("view.titlebar.color", "Titlebar Color","color", &self.config_file.values.titlebar_color),
         )
     }
 
-    pub fn write(&mut self, _name: &str, _value: &str) {
+    pub fn write(&mut self, id: &str, value: &str) {
+        match id {
+            "notes.path" => { self.config_file.values.base_dir = String::from(value);},
+            "screenshot.command" => { self.config_file.values.screenshot_command = String::from(value); },
+            "view.titlebar.color" => { self.config_file.values.titlebar_color = String::from(value); },
+            _ => {}
+        };
+
         self.save();
     }
 

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -31,9 +31,21 @@ struct ConfigValues {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ConfigValue {
+    pub id: String,
     pub name: String,
     pub data_type: String,
     pub value: String
+}
+
+impl ConfigValue {
+    fn new(id: &str, name: &str, data_type: &str, value: &str) -> Self {
+        ConfigValue {
+            id: String::from(id),
+            name: String::from(name),
+            data_type: String::from(data_type),
+            value: String::from(value),
+        }
+    }
 }
 
 
@@ -108,11 +120,9 @@ impl Config {
 
     pub fn read_all(&self) -> Vec<ConfigValue> {
         vec!(
-            ConfigValue {
-                name: String::from("base_path"),
-                data_type: String::from("string"),
-                value: String::from(&self.config_file.values.base_dir)
-            }
+            ConfigValue::new("notes.path", "Notes Directory","string", &self.config_file.values.base_dir),
+            ConfigValue::new("screenshot.command", "Screenshot Command","string", "gnome-screenshot -a {filename}"),
+            ConfigValue::new("view.titlebar.color", "Titlebar Color","color", "#b0b0b0"),
         )
     }
 

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -45,7 +45,7 @@ pub struct ConfigValue {
 }
 
 fn default_screenshot_command() -> String {
-    String::from("gnome-screenshot -a {filename}")
+    String::from("gnome-screenshot -a -f {filename}")
 }
 
 fn default_titlebar_color() -> String {
@@ -133,6 +133,23 @@ impl Config {
         let base_dir = &self.config_file.values.base_dir;
 
         PathBuf::from(base_dir.replace("{home}", &home_dir.to_string_lossy()))
+    }
+
+    pub fn get_screenshot_command(&self, filename: &str) -> (String, Vec<String>) {
+        let mut parts = self.config_file.values.screenshot_command.split(" ");
+        let first = parts.next();
+        if first.is_none() {
+            return (String::from("false"), vec!());
+        }
+
+        let command = String::from(first.unwrap());
+
+        let mut args: Vec<String> = vec!();
+        for part in parts {
+            args.push(String::from(if part != "{filename}" { part } else { filename }));
+        }
+
+        (command, args)
     }
 
     pub fn read_all(&self) -> Vec<ConfigValue> {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -112,7 +112,7 @@ async fn write_tags(context: tauri::State<'_, Context>, name: &str, tags: Vec<St
 #[tauri::command]
 async fn open_note_directory(context: tauri::State<'_, Context>, name: &str) -> NoteResult<()> {
   let config = context.0.lock().unwrap();
-  note::open_note_direcotry(&config, name)
+  note::open_note_directory(&config, name)
 }
 
 #[tauri::command]

--- a/src-tauri/src/note.rs
+++ b/src-tauri/src/note.rs
@@ -88,8 +88,10 @@ pub fn take_screenshot(config: &Config, name: &str) -> NoteResult<String> {
   let filename = format!("screenshot_{}.png", id);
   let path = Path::new(&get_note_path(&config, name)?).join(filename.clone());
 
-  let status = Command::new("gnome-screenshot")
-    .args(["-a", "-f", &path.to_string_lossy()])
+  let (cmd, args) = config.get_screenshot_command(&path.to_string_lossy());
+
+  let status = Command::new(cmd)
+    .args(args)
     .status()?;
   
   match status.code() {

--- a/src-tauri/src/note.rs
+++ b/src-tauri/src/note.rs
@@ -105,7 +105,7 @@ pub fn read_attachment(config: &Config, name: &str, attachment: &str, data: &mut
   Ok(())
 }
 
-pub fn open_note_direcotry(config: &Config, name: &str) -> NoteResult<()> {
+pub fn open_note_directory(config: &Config, name: &str) -> NoteResult<()> {
   let path = get_note_path(&config, name)?;
   opener::open(path.as_path())?;
   Ok(())


### PR DESCRIPTION
This PR implements the settings page.

Changes:
- save settings to config file
- make notes path configurable and reload on change (major refactoring)
- make screenshot command editable; use configured screenshot command
- save last change on close
- sort notes on load
- note.rs is now stateless, the config object is provided at each call
- main.rs: introduce Context struct to encapsulate the configuration